### PR TITLE
Fix Hibernate dialect error by setting driver and dialect

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,6 +3,8 @@
 spring.datasource.url=${JDBC_DATABASE_URL:jdbc:mysql://localhost:3306/resume_db?useSSL=false&serverTimezone=UTC}
 spring.datasource.username=${JDBC_DATABASE_USERNAME:root}
 spring.datasource.password=${JDBC_DATABASE_PASSWORD:password}
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.jpa.database-platform=org.hibernate.dialect.MySQLDialect
 
 # Automatically update the database schema to match the JPA entities. In
 # production you may want to change this to validate or none.


### PR DESCRIPTION
## Summary
- specify MySQL JDBC driver and Hibernate dialect so JPA can initialize without database metadata

## Testing
- `mvn -q -e -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6893d636d13c8323bc9ed70a83534627